### PR TITLE
Fix the problem about not numerical value.

### DIFF
--- a/lib/Method/Generate/Accessor/Role/LvalueAttribute.pm
+++ b/lib/Method/Generate/Accessor/Role/LvalueAttribute.pm
@@ -16,7 +16,7 @@ around generate_method => sub {
     my $orig = shift;
     my $self = shift;
     # would like a better way to disable XS
-    
+
     my ($into, $name, $spec, $quote_opts) = @_;
 
     $MooX::LvalueAttribute::INJECTED_IN_ROLE{$into}
@@ -54,8 +54,14 @@ around generate_method => sub {
             my $self = shift;
             if (! exists $LVALUES{$self}{$lv_name}) {
                 my $wiz = wizard(
-                 set  => sub { $self->$name(${$_[0]}) },
-                 get => sub { ${$_[0]} = $self->$name() },
+                 set  => sub {
+                     $self->$name(${$_[0]});
+                     return 1;
+                 },
+                 get => sub {
+                     ${$_[0]} = $self->$name();
+                     return 1;
+                 },
                 );
                 cast $LVALUES{$self}{$lv_name}, $wiz;
             }

--- a/t/lvalue.t
+++ b/t/lvalue.t
@@ -55,4 +55,9 @@ like $@, qr/Can't modify non-lvalue subroutine|Modification of a read-only value
 my $lvalue2 = MooLvalue->new(two => 7);
 is $lvalue2->two, 7, "different instances have different values";
 
+my $lvalue3 = MooLvalue->new(two => 'foo');
+is $lvalue3->two, 'foo', "not numerical values getter works";
+$lvalue3->two = 'bar';
+is $lvalue3->two, 'bar', "not numerical values setter works";
+
 done_testing;


### PR DESCRIPTION
Hi,

MooX::LvalueAttribute does not work certainly if it is given not numerical value (e.g. string).
https://gist.github.com/moznion/6895043
The above code is the SYNOPSIS of MooX::LvalueAttribute, but it does not work.

The cause is Variable::Magic.
https://gist.github.com/moznion/6896660
Code references in `wizard()` expects the return value as numerical value.
However MooX::LvalueAttribute does not meet this condition.

So I fixed it.
Could you review and merge this?
